### PR TITLE
Fixing breaking changes in RabbitMQ.Client 6.0.0

### DIFF
--- a/src/RabbitMQ.Client.Core.DependencyInjection/Configuration/RabbitMqClientOptions.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/Configuration/RabbitMqClientOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Core.DependencyInjection.Configuration
 {
@@ -76,11 +77,11 @@ namespace RabbitMQ.Client.Core.DependencyInjection.Configuration
         /// <summary>
         /// Timeout for connection attempts.
         /// </summary>
-        public int RequestedConnectionTimeout { get; set; } = 60000;
+        public TimeSpan RequestedConnectionTimeout { get; set; } = TimeSpan.FromMilliseconds(60000);
 
         /// <summary>
         /// Heartbeat timeout.
         /// </summary>
-        public ushort RequestedHeartbeat { get; set; } = 60;
+        public TimeSpan RequestedHeartbeat { get; set; } = TimeSpan.FromSeconds(60);
     }
 }

--- a/src/RabbitMQ.Client.Core.DependencyInjection/IProducingService.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/IProducingService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Core.DependencyInjection
 {
@@ -77,7 +78,7 @@ namespace RabbitMQ.Client.Core.DependencyInjection
         /// <param name="properties">Message properties.</param>
         /// <param name="exchangeName">Exchange name.</param>
         /// <param name="routingKey">Routing key.</param>
-        void Send(byte[] bytes, IBasicProperties properties, string exchangeName, string routingKey);
+        void Send(ReadOnlyMemory<byte> bytes, IBasicProperties properties, string exchangeName, string routingKey);
 
         /// <summary>
         /// Send a delayed message.
@@ -87,7 +88,7 @@ namespace RabbitMQ.Client.Core.DependencyInjection
         /// <param name="exchangeName">Exchange name.</param>
         /// <param name="routingKey">Routing key.</param>
         /// <param name="secondsDelay">Delay time.</param>
-        void Send(byte[] bytes, IBasicProperties properties, string exchangeName, string routingKey, int secondsDelay);
+        void Send(ReadOnlyMemory<byte> bytes, IBasicProperties properties, string exchangeName, string routingKey, int secondsDelay);
 
         /// <summary>
         /// Send a message asynchronously.
@@ -149,7 +150,7 @@ namespace RabbitMQ.Client.Core.DependencyInjection
         /// <param name="properties">Message properties.</param>
         /// <param name="exchangeName">Exchange name.</param>
         /// <param name="routingKey">Routing key.</param>
-        Task SendAsync(byte[] bytes, IBasicProperties properties, string exchangeName, string routingKey);
+        Task SendAsync(ReadOnlyMemory<byte> bytes, IBasicProperties properties, string exchangeName, string routingKey);
 
         /// <summary>
         /// Send a delayed message asynchronously.
@@ -159,6 +160,6 @@ namespace RabbitMQ.Client.Core.DependencyInjection
         /// <param name="exchangeName">Exchange name.</param>
         /// <param name="routingKey">Routing key.</param>
         /// <param name="secondsDelay">Delay time.</param>
-        Task SendAsync(byte[] bytes, IBasicProperties properties, string exchangeName, string routingKey, int secondsDelay);
+        Task SendAsync(ReadOnlyMemory<byte> bytes, IBasicProperties properties, string exchangeName, string routingKey, int secondsDelay);
     }
 }

--- a/src/RabbitMQ.Client.Core.DependencyInjection/MessageHandlingService.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/MessageHandlingService.cs
@@ -38,7 +38,7 @@ namespace RabbitMQ.Client.Core.DependencyInjection
         /// <param name="queueService">An instance of the queue service <see cref="IQueueService"/>.</param>
         public async Task HandleMessageReceivingEvent(BasicDeliverEventArgs eventArgs, IQueueService queueService)
         {
-            var message = Encoding.UTF8.GetString(eventArgs.Body);
+            var message = Encoding.UTF8.GetString(eventArgs.Body.ToArray());
 
             _logger.LogInformation($"A new message was received with deliveryTag {eventArgs.DeliveryTag}.");
             _logger.LogInformation(message);

--- a/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMQ.Client.Core.DependencyInjection.csproj
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMQ.Client.Core.DependencyInjection.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>3.2.1</Version>
+    <Version>6.0.0</Version>
     <PackageTags>RabbitMQ</PackageTags>
     <RepositoryUrl>https://github.com/AntonyVorontsov/RabbitMQ.Client.Core.DependencyInjection</RepositoryUrl>
     <Company />
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixing breaking changes in RabbitMQ.Client 6.0.0
- Fix: byte[] are now ReadOnlyMemory<byte>
- Fix: timeouts are now TimeSpan
- Fix: ConnectionRecoveryError moved to IAutorecoveringConnection

Bumping version to match RabbitMQ.Client (clearer IMHO)