### PR TITLE
enable usage of consumer and producer without cyclic dependency

### DIFF
--- a/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMqClientDependencyInjectionExtensions.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMqClientDependencyInjectionExtensions.cs
@@ -267,7 +267,7 @@ namespace RabbitMQ.Client.Core.DependencyInjection
                 guid,
                 provider.GetService<IRabbitMqConnectionFactory>(),
                 provider.GetServices<RabbitMqConnectionOptionsContainer>(),
-                provider.GetService<IMessageHandlingService>(),
+                new MessageHandlingMock(), 
                 provider.GetServices<RabbitMqExchange>(),
                 provider.GetService<ILogger<QueueService> >()));
             return services;

--- a/src/RabbitMQ.Client.Core.DependencyInjection/Services/MessageHandlingMock.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/Services/MessageHandlingMock.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMQ.Client.Core.DependencyInjection.Services
+{
+    public class MessageHandlingMock : IMessageHandlingService
+    {
+        public Task HandleMessageReceivingEvent(BasicDeliverEventArgs eventArgs, IQueueService queueService)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
with this slight change you are able to use producing service inside messagehandleres when registering them seperately.

I think thats quite handy as you can better utilize dependency injection