### PR TITLE
remove console logging

### DIFF
--- a/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMQ.Client.Core.DependencyInjection.csproj
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMQ.Client.Core.DependencyInjection.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
   </ItemGroup>

--- a/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMqClientDependencyInjectionExtensions.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/RabbitMqClientDependencyInjectionExtensions.cs
@@ -230,7 +230,7 @@ namespace RabbitMQ.Client.Core.DependencyInjection
         static IServiceCollection AddRabbitMqClientInfrastructure(this IServiceCollection services)
         {
             services.AddOptions();
-            services.AddLogging(options => options.AddConsole());
+            services.AddLogging();
             services.TryAddSingleton<IRabbitMqConnectionFactory, RabbitMqConnectionFactory>();
             services.TryAddSingleton<IMessageHandlerContainerBuilder, MessageHandlerContainerBuilder>();
             services.TryAddSingleton<IMessageHandlingService, MessageHandlingService>();


### PR DESCRIPTION
as a library author you should only depend on the logging abstraction.

I personally use serilog but in general the app developer should choose the logger.

it was quite hard to figure out why all of a sudden we had two loggers in our app fighting over the console 