### PR TITLE
Custom Initial Prefeth Count in consumer queue

### DIFF
--- a/src/RabbitMQ.Client.Core.DependencyInjection/Configuration/RabbitMqQueueOptions.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/Configuration/RabbitMqQueueOptions.cs
@@ -36,5 +36,11 @@ namespace RabbitMQ.Client.Core.DependencyInjection.Configuration
         /// Additional arguments.
         /// </summary>
         public IDictionary<string, object> Arguments { get; set; } = new Dictionary<string, object>();
+
+
+        /// <summary>
+        /// Initial prefetchCount
+        /// </summary>
+        public ushort PrefetchCount { get; set; } = 0;
     }
 }

--- a/src/RabbitMQ.Client.Core.DependencyInjection/Services/ConsumingService.cs
+++ b/src/RabbitMQ.Client.Core.DependencyInjection/Services/ConsumingService.cs
@@ -89,7 +89,10 @@ namespace RabbitMQ.Client.Core.DependencyInjection.Services
             var consumptionExchanges = _exchanges.Where(x => x.IsConsuming);
             _consumerTags = consumptionExchanges.SelectMany(
                     exchange => exchange.Options.Queues.Select(
-                        queue => Channel.BasicConsume(queue: queue.Name, autoAck: false, consumer: Consumer)))
+                        queue => {
+                            Channel.BasicQos(prefetchSize: 0, prefetchCount: queue.PrefetchCount, false);
+                            return Channel.BasicConsume(queue: queue.Name, autoAck: false, consumer: Consumer);
+                        }))
                 .Distinct()
                 .ToList();
         }


### PR DESCRIPTION
I'd like to request approval to include the prefetch count setting when starting queue consumers automatically. Please approve the pull request.